### PR TITLE
Fix dark mode script and unify utility page styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -803,6 +803,11 @@ img {
   gap: 2rem;
 }
 
+.utilities__description{
+  color: var(--text-color-light);
+  margin-bottom: var(--mb-1);
+}
+
 .utilities__input-group,
 .utilities__output-group{
   display: flex;
@@ -847,25 +852,102 @@ img {
   justify-content: center;
 }
 
-/* Estilos específicos para a página do formatador SQL */
-.utilities__container {
+/* Estilos específicos para páginas de utilidades individuais */
+.formatador-sql .utilities__container,
+.pixel-art .utilities__container{
   grid-template-columns: 1fr;
 }
 
-.utilities__container .utilities__content {
+.formatador-sql .utilities__container .utilities__content,
+.pixel-art .utilities__container .utilities__content{
   max-width: 100%;
   width: 100%;
   margin: 0 auto;
 }
 
-.utilities__textarea {
+.formatador-sql .utilities__textarea{
   min-height: 300px;
 }
 
-.utilities__output {
+.formatador-sql .utilities__output{
   background-color: var(--body-color);
   border-color: var(--first-color);
   font-weight: 500;
+}
+
+/* ==========================PIXEL ART========================= */
+.pixel-art {
+  --gap: 12px;
+}
+
+.pixel-art .row{
+  display: flex;
+  gap: var(--gap);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.pixel-art .row--top{
+  margin-top: var(--gap);
+}
+
+.pixel-art .row--start{
+  align-items: flex-start;
+}
+
+.pixel-art .col{
+  display: grid;
+  gap: 8px;
+}
+
+.pixel-art canvas{
+  image-rendering: pixelated;
+  border: 1px solid var(--text-color-light);
+  background: var(--container-color);
+  cursor: crosshair;
+}
+
+.pixel-art .kv{
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.pixel-art .swatch{
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--text-color-light);
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.pixel-art label{
+  white-space: nowrap;
+}
+
+.pixel-art input[type="number"]{
+  width: 7em;
+}
+
+.pixel-art fieldset{
+  border: 1px solid var(--text-color-light);
+  padding: 8px 10px;
+  border-radius: 8px;
+}
+
+.pixel-art legend{
+  font-size: 0.95rem;
+  color: var(--title-color);
+  padding: 0 6px;
+}
+
+.pixel-art .pixel-notes{
+  max-width: 360px;
+  font-size: 0.92rem;
+  color: var(--title-color);
+}
+
+.pixel-art button{
+  padding: 6px 10px;
+  cursor: pointer;
 }
 
 .contact__container{

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,19 +1,21 @@
 const image = document.getElementById("profile-image");
-image.addEventListener("click", () => {
-  const images = [
-    "./assets/imagens/avatar/avatar1.png",
-    "./assets/imagens/avatar/avatar2.png",
-    "./assets/imagens/avatar/avatar3.png",
-    "./assets/imagens/avatar/avatar4.png",
-    "./assets/imagens/avatar/avatar5.png",
-    "./assets/imagens/avatar/avatar6.png",
-    "./assets/imagens/avatar/avatar7.png",
-    "./assets/imagens/avatar/avatar8.png",
-  ];
+if (image) {
+  image.addEventListener("click", () => {
+    const images = [
+      "./assets/imagens/avatar/avatar1.png",
+      "./assets/imagens/avatar/avatar2.png",
+      "./assets/imagens/avatar/avatar3.png",
+      "./assets/imagens/avatar/avatar4.png",
+      "./assets/imagens/avatar/avatar5.png",
+      "./assets/imagens/avatar/avatar6.png",
+      "./assets/imagens/avatar/avatar7.png",
+      "./assets/imagens/avatar/avatar8.png",
+    ];
 
-  const randomImage = images[Math.floor(Math.random() * images.length)];
-  image.setAttribute("href", randomImage);
-});
+    const randomImage = images[Math.floor(Math.random() * images.length)];
+    image.setAttribute("href", randomImage);
+  });
+}
 
 const navMenu = document.getElementById("nav-menu"),
   navToggle = document.getElementById("nav-toggle"),
@@ -99,18 +101,20 @@ modalCloses.forEach((modalClose) => {
   })
 })
 
-var swiperPortfolio = new Swiper(".portfolio__container", {
-  cssMode: true,
-  loop: true,
-  navigation: {
-    nextEl: ".swiper-button-next",
-    prevEl: ".swiper-button-prev",
-  },
-  pagination: {
-    el: ".swiper-pagination",
-    clickable: true,
-  },
-});
+if (typeof Swiper !== 'undefined' && document.querySelector('.portfolio__container')) {
+  var swiperPortfolio = new Swiper('.portfolio__container', {
+    cssMode: true,
+    loop: true,
+    navigation: {
+      nextEl: '.swiper-button-next',
+      prevEl: '.swiper-button-prev',
+    },
+    pagination: {
+      el: '.swiper-pagination',
+      clickable: true,
+    },
+  });
+}
 
 const sections = document.querySelectorAll('section[id]')
 

--- a/formatador_sql.html
+++ b/formatador_sql.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="./assets/css/style.css" />
   </head>
 
-  <body>
+  <body class="formatador-sql">
     <header class="header" id="header">
       <nav class="nav container">
         <a href="index.html" class="nav__logo">Mustafa</a>

--- a/pixel_art_generator.html
+++ b/pixel_art_generator.html
@@ -1,111 +1,116 @@
 <!DOCTYPE html>
 <html lang="pt-br">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Pixel Inspector | Mustafa Neto</title>
-<link
-  rel="stylesheet"
-  href="https://unicons.iconscout.com/release/v4.0.0/css/line.css"
-/>
-<link rel="stylesheet" href="./assets/css/style.css" />
-<style>
-  :root { --gap: 12px; }
-  body { 
-    font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, sans-serif; 
-    margin: 16px; 
-    padding-top: calc(var(--header-heigth) + 2rem);
-  }
-  .row { display: flex; gap: var(--gap); align-items: center; flex-wrap: wrap; }
-  .col { display: grid; gap: 8px; }
-  canvas { image-rendering: pixelated; border: 1px solid #ccc; background: #fff; cursor: crosshair; }
-  .kv { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-  .swatch { width: 24px; height: 24px; border: 1px solid #aaa; display: inline-block; vertical-align: middle; }
-  label { white-space: nowrap; }
-  input[type="number"] { width: 7em; }
-  fieldset { border: 1px solid #ddd; padding: 8px 10px; border-radius: 8px; }
-  legend { font-size: 0.95rem; color: #333; padding: 0 6px; }
-  button { padding: 6px 10px; cursor: pointer; }
-</style>
-</head>
-<body>
-<header class="header" id="header">
-  <nav class="nav container">
-    <a href="index.html" class="nav__logo">Mustafa</a>
-    <div class="nav__menu" id="nav-menu">
-      <ul class="nav__list grid">
-        <li class="nav__item">
-          <a href="utilidades.html" class="nav__link">
-            <i class="uil uil-apps nav__icon"></i>
-            Voltar às Utilidades
-          </a>
-        </li>
-      </ul>
-      <i class="uil uil-times nav__close" id="nav-close"></i>
-    </div>
-    <div class="nav__btns">
-      <i class="uil uil-moon change-theme" id="theme-button"></i>
-      <div class="nav__toggle" id="nav-toggle">
-        <i class="uil uil-apps"></i>
-      </div>
-    </div>
-  </nav>
-</header>
-<h1>Pixel Inspector</h1>
-<p style="color: #666; margin-bottom: 12px;">Clique em um pixel para selecioná-lo e ver suas informações. Clique novamente no mesmo pixel para deselecionar.</p>
-<div class="row">
-  <label>Image: <input id="file" type="file" accept="image/*"></label>
-  <label>Target W: <input id="tw" type="number" value="75" min="1"></label>
-  <label>Target H: <input id="th" type="number" value="76" min="1"></label>
-  <label><input id="resize" type="checkbox" checked> Resize to target (nearest‑neighbor)</label>
-  <label><input id="grid" type="checkbox" checked> Show grid</label>
-  <label><input id="snap" type="checkbox" checked> Snap to pixel</label>
-  <label>Zoom: <input id="zoom" type="range" min="1" max="32" step="1" value="8"></label>
-</div>
-<div class="row" style="margin-top:12px;">
-  <canvas id="view" width="600" height="600"></canvas>
-  <div class="col">
-    <div class="kv">Image size (px): <span id="size">–</span></div>
-    <div class="kv">Cursor (displayed): <span id="pos">–</span></div>
-    <div class="kv">Image coords: <span id="ipos">–</span></div>
-    <div class="kv">Color: <span id="rgb">–</span> <span id="hex">–</span>
-      <span id="sw" class="swatch"></span>
-    </div>
-    <div class="row">
-      <button id="copyHex" disabled>Copy HEX</button>
-      <button id="copyRGB" disabled>Copy RGB</button>
-      <button id="copyColor" disabled>Copy Color</button>
-    </div>
-    <fieldset>
-      <legend>Custom Origin</legend>
-      <div class="row">
-        <label><input id="customOrigin" type="checkbox"> Use custom origin</label>
-      </div>
-      <div class="row">
-        <label>OX: <input id="originX" type="number" value="0"></label>
-        <label>OY: <input id="originY" type="number" value="0"></label>
-        <button id="setFromHover" title="Set OX/OY from selected pixel">Set from Selection</button>
-      </div>
-      <div class="row" style="align-items:flex-start;">
-        <fieldset>
-          <legend>Mode</legend>
-          <label title="image (0,0) will be displayed as (OX, OY)">
-            <input type="radio" name="originMode" value="offset" checked> Offset
-          </label><br>
-          <label title="coord (0,0) equals image (OX, OY); e.g., set OX=1723, OY=2424">
-            <input type="radio" name="originMode" value="anchor"> Anchor
-          </label>
-        </fieldset>
-        <div style="max-width:360px; font-size:0.92rem; color:#333;">
-          <b>Offset</b>: displayed = (imgX + OX, imgY + OY).<br>
-          <b>Anchor</b>: displayed = (imgX − OX, imgY − OY).<br>
-          Example: to make <i>coord (0,0)</i> be image pixel <i>(1723,2424)</i>, choose <b>Anchor</b> and set OX=<b>1723</b>, OY=<b>2424</b>.
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Pixel Inspector | Mustafa Neto</title>
+    <link
+      rel="stylesheet"
+      href="https://unicons.iconscout.com/release/v4.0.0/css/line.css"
+    />
+    <link rel="stylesheet" href="./assets/css/style.css" />
+  </head>
+  <body class="pixel-art">
+    <header class="header" id="header">
+      <nav class="nav container">
+        <a href="index.html" class="nav__logo">Mustafa</a>
+        <div class="nav__menu" id="nav-menu">
+          <ul class="nav__list grid">
+            <li class="nav__item">
+              <a href="utilidades.html" class="nav__link">
+                <i class="uil uil-apps nav__icon"></i>
+                Voltar às Utilidades
+              </a>
+            </li>
+          </ul>
+          <i class="uil uil-times nav__close" id="nav-close"></i>
         </div>
-      </div>
-    </fieldset>
-  </div>
-  </div>
+        <div class="nav__btns">
+          <i class="uil uil-moon change-theme" id="theme-button"></i>
+          <div class="nav__toggle" id="nav-toggle">
+            <i class="uil uil-apps"></i>
+          </div>
+        </div>
+      </nav>
+    </header>
 
+    <main class="main">
+      <section class="utilities section" id="utilities">
+        <h2 class="section__title">Pixel Inspector</h2>
+        <span class="section__subtitle">Ferramenta para inspecionar pixels</span>
+
+        <div class="utilities__container container grid">
+          <div class="utilities__content">
+            <div class="utilities__header">
+              <i class="uil uil-brush-alt utilities__icon"></i>
+              <h3 class="utilities__title">Pixel Inspector</h3>
+            </div>
+
+            <div class="utilities__tool">
+              <p class="utilities__description">
+                Clique em um pixel para selecioná-lo e ver suas informações.
+                Clique novamente no mesmo pixel para deselecionar.
+              </p>
+
+              <div class="row">
+                <label>Image: <input id="file" type="file" accept="image/*" /></label>
+                <label>Target W: <input id="tw" type="number" value="75" min="1" /></label>
+                <label>Target H: <input id="th" type="number" value="76" min="1" /></label>
+                <label><input id="resize" type="checkbox" checked /> Resize to target (nearest‑neighbor)</label>
+                <label><input id="grid" type="checkbox" checked /> Show grid</label>
+                <label><input id="snap" type="checkbox" checked /> Snap to pixel</label>
+                <label>Zoom: <input id="zoom" type="range" min="1" max="32" step="1" value="8" /></label>
+              </div>
+
+              <div class="row row--top">
+                <canvas id="view" width="600" height="600"></canvas>
+                <div class="col">
+                  <div class="kv">Image size (px): <span id="size">–</span></div>
+                  <div class="kv">Cursor (displayed): <span id="pos">–</span></div>
+                  <div class="kv">Image coords: <span id="ipos">–</span></div>
+                  <div class="kv">
+                    Color: <span id="rgb">–</span> <span id="hex">–</span>
+                    <span id="sw" class="swatch"></span>
+                  </div>
+                  <div class="row">
+                    <button id="copyHex" disabled>Copy HEX</button>
+                    <button id="copyRGB" disabled>Copy RGB</button>
+                    <button id="copyColor" disabled>Copy Color</button>
+                  </div>
+                  <fieldset>
+                    <legend>Custom Origin</legend>
+                    <div class="row">
+                      <label><input id="customOrigin" type="checkbox" /> Use custom origin</label>
+                    </div>
+                    <div class="row">
+                      <label>OX: <input id="originX" type="number" value="0" /></label>
+                      <label>OY: <input id="originY" type="number" value="0" /></label>
+                      <button id="setFromHover" title="Set OX/OY from selected pixel">Set from Selection</button>
+                    </div>
+                    <div class="row row--start">
+                      <fieldset>
+                        <legend>Mode</legend>
+                        <label title="image (0,0) will be displayed as (OX, OY)">
+                          <input type="radio" name="originMode" value="offset" checked /> Offset
+                        </label><br />
+                        <label title="coord (0,0) equals image (OX, OY); e.g., set OX=1723, OY=2424">
+                          <input type="radio" name="originMode" value="anchor" /> Anchor
+                        </label>
+                      </fieldset>
+                      <div class="pixel-notes">
+                        <b>Offset</b>: displayed = (imgX + OX, imgY + OY).<br />
+                        <b>Anchor</b>: displayed = (imgX − OX, imgY − OY).<br />
+                        Example: to make <i>coord (0,0)</i> be image pixel <i>(1723,2424)</i>, choose <b>Anchor</b> and set OX=<b>1723</b>, OY=<b>2424</b>.
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
 <footer class="footer">
   <div class="footer__bg">
     <div class="footer__container container grid">


### PR DESCRIPTION
## Summary
- guard profile image click handler so theme toggle works everywhere
- guard Swiper initialization to avoid errors when library is missing
- move utility pages to site-wide layout and centralize styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689229b960f083288c6a99b9e88a4c14