### PR TITLE
Improve pixel art generator layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -859,13 +859,27 @@ img {
   grid-template-columns: 1fr;
 }
 
-.formatador-sql .utilities__container .utilities__content,
-.pixel-art .utilities__container .utilities__content{
+.pixel-art .utilities__container.container{
+  max-width: 100%;
+  width: 100%;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.formatador-sql .utilities__container .utilities__content{
   max-width: 100%;
   width: 100%;
   margin: 0 auto;
   min-height: 80vh;
   padding: 2rem;
+}
+
+.pixel-art .utilities__container .utilities__content{
+  max-width: none;
+  width: 100%;
+  margin: 0;
+  min-height: 80vh;
+  padding: 1rem;
 }
 
 .formatador-sql .utilities__textarea{
@@ -914,10 +928,13 @@ img {
 }
 
 .canvas-container {
+  flex: 1;
+  display: flex;
   min-width: 0;
   justify-content: center;
   align-items: flex-start;
   min-height: 500px;
+  overflow: auto;
 }
 
 .info-panel {
@@ -949,7 +966,7 @@ img {
   border: 1px solid var(--text-color-light);
   background: var(--container-color);
   cursor: crosshair;
-  max-width: 100%;
+  max-width: none;
   height: auto;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }


### PR DESCRIPTION
## Summary
- allow the pixel art tool to use the full screen width
- ensure the canvas flexes and scrolls so large images remain usable

## Testing
- `npx prettier assets/css/style.css pixel_art_generator.html --check` *(warned about code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_6892355c37f0832884ec12b3bed63331