### PR TITLE
feat: show color name for selected pixels

### DIFF
--- a/pixel_art_generator.html
+++ b/pixel_art_generator.html
@@ -71,7 +71,7 @@
                   <div class="kv">Cursor (displayed): <span id="pos">–</span></div>
                   <div class="kv">Image coords: <span id="ipos">–</span></div>
                   <div class="kv">
-                    Color: <span id="rgb">–</span> <span id="hex">–</span>
+                    Color: <span id="colorName">–</span> <span id="rgb">–</span> <span id="hex">–</span>
                     <span id="sw" class="swatch"></span>
                   </div>
                   <div class="row">
@@ -152,6 +152,7 @@
   const posEl = $('pos');
   const iposEl = $('ipos');
   const rgbEl = $('rgb');
+  const colorNameEl = $('colorName');
   const hexEl = $('hex');
   const sw = $('sw');
   const copyHex = $('copyHex');
@@ -166,69 +167,69 @@
   let bctx = base.getContext('2d', { willReadFrequently: true });
   let zoom = +zoomEl.value;
   const palette = [
-    [0, 0, 0],
-    [60, 60, 60],
-    [120, 120, 120],
-    [170, 170, 170],
-    [210, 210, 210],
-    [255, 255, 255],
-    [96, 0, 24],
-    [165, 14, 30],
-    [237, 28, 36],
-    [250, 128, 114],
-    [228, 92, 26],
-    [255, 127, 39],
-    [246, 170, 9],
-    [249, 221, 59],
-    [255, 250, 188],
-    [156, 132, 49],
-    [197, 173, 49],
-    [232, 212, 95],
-    [74, 107, 58],
-    [90, 148, 74],
-    [132, 197, 115],
-    [14, 185, 104],
-    [19, 230, 123],
-    [135, 255, 94],
-    [12, 129, 110],
-    [16, 174, 166],
-    [19, 225, 190],
-    [15, 121, 159],
-    [96, 247, 242],
-    [187, 250, 242],
-    [40, 80, 158],
-    [64, 147, 228],
-    [125, 199, 255],
-    [77, 49, 184],
-    [107, 80, 246],
-    [153, 177, 251],
-    [74, 66, 132],
-    [122, 113, 196],
-    [181, 174, 241],
-    [120, 12, 153],
-    [170, 56, 185],
-    [224, 159, 249],
-    [203, 0, 122],
-    [236, 31, 128],
-    [243, 141, 169],
-    [155, 82, 73],
-    [209, 128, 120],
-    [250, 182, 164],
-    [104, 70, 52],
-    [149, 104, 42],
-    [219, 164, 99],
-    [123, 99, 82],
-    [156, 132, 107],
-    [214, 181, 148],
-    [209, 128, 81],
-    [248, 178, 119],
-    [255, 197, 165],
-    [109, 100, 63],
-    [148, 140, 107],
-    [205, 197, 158],
-    [51, 57, 65],
-    [109, 117, 141],
-    [179, 185, 209]
+    { r: 0, g: 0, b: 0, name: 'Black' },
+    { r: 60, g: 60, b: 60, name: 'Dark Gray' },
+    { r: 120, g: 120, b: 120, name: 'Gray' },
+    { r: 170, g: 170, b: 170, name: 'Medium Gray' },
+    { r: 210, g: 210, b: 210, name: 'Light Gray' },
+    { r: 255, g: 255, b: 255, name: 'White' },
+    { r: 96, g: 0, b: 24, name: 'Deep Red' },
+    { r: 165, g: 14, b: 30, name: 'Dark Red' },
+    { r: 237, g: 28, b: 36, name: 'Red' },
+    { r: 250, g: 128, b: 114, name: 'Light Red' },
+    { r: 228, g: 92, b: 26, name: 'Dark Orange' },
+    { r: 255, g: 127, b: 39, name: 'Orange' },
+    { r: 246, g: 170, b: 9, name: 'Gold' },
+    { r: 249, g: 221, b: 59, name: 'Yellow' },
+    { r: 255, g: 250, b: 188, name: 'Light Yellow' },
+    { r: 156, g: 132, b: 49, name: 'Dark Goldenrod' },
+    { r: 197, g: 173, b: 49, name: 'Goldenrod' },
+    { r: 232, g: 212, b: 95, name: 'Light Goldenrod' },
+    { r: 74, g: 107, b: 58, name: 'Dark Olive' },
+    { r: 90, g: 148, b: 74, name: 'Olive' },
+    { r: 132, g: 197, b: 115, name: 'Light Olive' },
+    { r: 14, g: 185, b: 104, name: 'Dark Green' },
+    { r: 19, g: 230, b: 123, name: 'Green' },
+    { r: 135, g: 255, b: 94, name: 'Light Green' },
+    { r: 12, g: 129, b: 110, name: 'Dark Teal' },
+    { r: 16, g: 174, b: 166, name: 'Teal' },
+    { r: 19, g: 225, b: 190, name: 'Light Teal' },
+    { r: 15, g: 121, b: 159, name: 'Dark Cyan' },
+    { r: 96, g: 247, b: 242, name: 'Cyan' },
+    { r: 187, g: 250, b: 242, name: 'Light Cyan' },
+    { r: 40, g: 80, b: 158, name: 'Dark Blue' },
+    { r: 64, g: 147, b: 228, name: 'Blue' },
+    { r: 125, g: 199, b: 255, name: 'Light Blue' },
+    { r: 77, g: 49, b: 184, name: 'Dark Indigo' },
+    { r: 107, g: 80, b: 246, name: 'Indigo' },
+    { r: 153, g: 177, b: 251, name: 'Light Indigo' },
+    { r: 74, g: 66, b: 132, name: 'Dark Slate Blue' },
+    { r: 122, g: 113, b: 196, name: 'Slate Blue' },
+    { r: 181, g: 174, b: 241, name: 'Light Slate Blue' },
+    { r: 120, g: 12, b: 153, name: 'Dark Purple' },
+    { r: 170, g: 56, b: 185, name: 'Purple' },
+    { r: 224, g: 159, b: 249, name: 'Light Purple' },
+    { r: 203, g: 0, b: 122, name: 'Dark Pink' },
+    { r: 236, g: 31, b: 128, name: 'Pink' },
+    { r: 243, g: 141, b: 169, name: 'Light Pink' },
+    { r: 155, g: 82, b: 73, name: 'Dark Peach' },
+    { r: 209, g: 128, b: 120, name: 'Peach' },
+    { r: 250, g: 182, b: 164, name: 'Light Peach' },
+    { r: 104, g: 70, b: 52, name: 'Dark Brown' },
+    { r: 149, g: 104, b: 42, name: 'Brown' },
+    { r: 219, g: 164, b: 99, name: 'Light Brown' },
+    { r: 123, g: 99, b: 82, name: 'Dark Tan' },
+    { r: 156, g: 132, b: 107, name: 'Tan' },
+    { r: 214, g: 181, b: 148, name: 'Light Tan' },
+    { r: 209, g: 128, b: 81, name: 'Dark Belge' },
+    { r: 248, g: 178, b: 119, name: 'Belge' },
+    { r: 255, g: 197, b: 165, name: 'Light Belge' },
+    { r: 109, g: 100, b: 63, name: 'Dark Stone' },
+    { r: 148, g: 140, b: 107, name: 'Stone' },
+    { r: 205, g: 197, b: 158, name: 'Light Stone' },
+    { r: 51, g: 57, b: 65, name: 'Dark Slate' },
+    { r: 109, g: 117, b: 141, name: 'Slate' },
+    { r: 179, g: 185, b: 209, name: 'Light Slate' }
   ];
   function currentOriginMode() {
     return [...originModeEls].find(r => r.checked)?.value || 'offset';
@@ -267,18 +268,18 @@
       let best = palette[0];
       let bestDist = Infinity;
       for (const col of palette) {
-        const dr = r - col[0];
-        const dg = g - col[1];
-        const db = b - col[2];
+        const dr = r - col.r;
+        const dg = g - col.g;
+        const db = b - col.b;
         const dist = dr * dr + dg * dg + db * db;
         if (dist < bestDist) {
           bestDist = dist;
           best = col;
         }
       }
-      data[i] = best[0];
-      data[i + 1] = best[1];
-      data[i + 2] = best[2];
+      data[i] = best.r;
+      data[i + 1] = best.g;
+      data[i + 2] = best.b;
     }
     bctx.putImageData(imgData, 0, 0);
   }
@@ -323,7 +324,8 @@
     const d = bctx.getImageData(x, y, 1, 1).data;
     const rgb = `rgb(${d[0]}, ${d[1]}, ${d[2]})`;
     const hex = '#' + [d[0], d[1], d[2]].map(v => v.toString(16).padStart(2, '0')).join('');
-    return { r: d[0], g: d[1], b: d[2], a: d[3], rgb, hex };
+    const name = palette.find(c => c.r === d[0] && c.g === d[1] && c.b === d[2])?.name || 'Unknown';
+    return { r: d[0], g: d[1], b: d[2], a: d[3], rgb, hex, name };
   }
   function displayFromImage(px, py) {
     const ox = +originXEl.value || 0;
@@ -344,18 +346,20 @@
     }
     const p = (px == null) ? null : getPixel(px, py);
     if (!p) {
+      colorNameEl.textContent = '–';
       rgbEl.textContent = '–';
       hexEl.textContent = '–';
       sw.style.background = 'transparent';
       copyHex.disabled = copyRGB.disabled = copyColor.disabled = true;
     } else {
+      colorNameEl.textContent = p.name;
       rgbEl.textContent = p.rgb;
       hexEl.textContent = p.hex;
       sw.style.background = p.hex;
       copyHex.disabled = copyRGB.disabled = copyColor.disabled = false;
       copyHex.onclick = () => navigator.clipboard.writeText(p.hex);
       copyRGB.onclick = () => navigator.clipboard.writeText(p.rgb);
-      copyColor.onclick = () => navigator.clipboard.writeText(p.hex);
+      copyColor.onclick = () => navigator.clipboard.writeText(p.name);
     }
   }
   function imageCoordsFromMouse(e) {


### PR DESCRIPTION
## Summary
- display color names when inspecting pixels
- include named palette and allow copying color names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924944023083288875808a58dd7a65